### PR TITLE
Added VS Code build tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,68 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Compile",
+      "type": "shell",
+      "linux": {
+        "command": "./build/compiler.elf",
+        "args": [
+          "${relativeFile}",
+          "${relativeFileDirname}/${fileBasenameNoExtension}"
+        ]
+      },
+      "windows": {
+        "command": ".\\build\\compiler.exe",
+        "args": [
+          "${relativeFile}",
+          "${relativeFileDirname}\\${fileBasenameNoExtension}.exe"
+        ]
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Compile and run",
+      "type": "shell",
+      "dependsOn": ["Compile"],
+      "linux": {
+        "command": "${relativeFileDirname}/${fileBasenameNoExtension}"
+      },
+      "windows": {
+        "command": "${relativeFileDirname}\\${fileBasenameNoExtension}.exe"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Compile and run with arguments",
+      "type": "shell",
+      "dependsOn": ["Compile"],
+      "linux": {
+        "command": "${relativeFileDirname}/${fileBasenameNoExtension}"
+      },
+      "windows": {
+        "command": "${relativeFileDirname}\\${fileBasenameNoExtension}.exe"
+      },
+      "args": ["${input:args}"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    }
+  ],
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "args",
+      "description": "Additional commandline arguments."
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,14 +5,14 @@
       "label": "Compile",
       "type": "shell",
       "linux": {
-        "command": "./build/compiler.elf",
+        "command": "build/compiler.elf",
         "args": [
           "${relativeFile}",
           "${relativeFileDirname}/${fileBasenameNoExtension}"
         ]
       },
       "windows": {
-        "command": ".\\build\\compiler.exe",
+        "command": "build\\compiler.exe",
         "args": [
           "${relativeFile}",
           "${relativeFileDirname}\\${fileBasenameNoExtension}.exe"


### PR DESCRIPTION
I wrote this for personal use but thought it could be useful in the repo. No worries if you don't want to accept it :)

Adds three build tasks:
1. Compile – Just runs `<compiler> <file>.rlx <file>` (or `<compiler> <file>.rlx <file>.exe` on Windows)
2. Compile and run – runs 1 and then runs the output file on success
3. Compile and run with arguments – same as 2 but asks for commandline arguments to pass to the output file

All paths are relative to the workspace root.